### PR TITLE
大佬，发现您的项目引入了org.jsoup:jsoup@1.13.1组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>bkhn.att</groupId>
     <artifactId>CrawlVanBan</artifactId>
@@ -27,7 +25,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.13.1</version>
+            <version>1.14.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Github jsoup安全漏洞
缺陷组件：org.jsoup:jsoup@1.13.1
漏洞编号：CVE-2021-37714
漏洞描述：Github jsoup是一个用于处理真实世界 HTML 的 Java 库。
jsoup 1.14.2之前版本存在安全漏洞，该漏洞可导致jsoup拒绝服务。
影响范围：(∞, 1.14.2)
最小修复版本：1.14.2
缺陷组件引入路径：bkhn.att:CrawlVanBan@0.0.1-SNAPSHOT->org.jsoup:jsoup@1.13.1
```
另外我运行这个项目时，IDE的安全插件提示还有1个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p021a5